### PR TITLE
Export data to csv 

### DIFF
--- a/data/exports.js
+++ b/data/exports.js
@@ -1,0 +1,27 @@
+import { ObjectId } from 'mongodb';
+import { projects } from '../config/mongoCollections.js';
+import { Parser } from 'json2csv';
+import fs from 'fs';
+import path from 'path';
+
+// Export data as CSV
+export const exportToCSV = async () => {
+    const projectCollection = await projects();
+    const data = await projectCollection.find({}).toArray();
+
+    if (data.length === 0) {
+        throw new Error('No projects found to export');
+    }
+
+    const fields = Object.keys(data[0]);
+    const parser = new Parser({ fields });
+    const csv = parser.parse(data);
+
+    const exportDir = path.join('public', 'exports');
+    fs.mkdirSync(exportDir, { recursive: true });
+
+    const filePath = path.join(exportDir, 'projects.csv');
+    fs.writeFileSync(filePath, csv);
+
+    return filePath;
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-handlebars": "^8.0.1",
+    "json2csv": "^6.0.0-alpha.2",
     "mongodb": "^6.13.1",
     "xlsx": "^0.18.5"
   },

--- a/routes/export.js
+++ b/routes/export.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import * as exportMethods  from '../data/exports.js';
+
+const router = Router();
+
+router.route('/').get(async (req, res) => {
+    try {
+        const filePath = await exportMethods.exportToCSV();
+        res.download(filePath, 'data.csv');
+    } catch (e) {
+      return res.status(500).json(e);
+    }
+    //code here for GET
+  });
+
+  export default router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,6 +2,7 @@ import {static as staticDir} from 'express';
 import homeRouter from './home.js';
 import projectsRouter  from './projects.js';
 import userAuthenticationRouter from './userAuthentication.js';
+import exportRouter from './export.js';
 
 
 const constructorMethod = (app) => {
@@ -10,6 +11,7 @@ const constructorMethod = (app) => {
     app.use('/', homeRouter);
     app.use('/login', userAuthenticationRouter)
     app.use('/projects', projectsRouter);
+    app.use('/export', exportRouter);
     app.use('/public', staticDir('public'));
     
     app.use('*', (req, res) => {


### PR DESCRIPTION
- Added functionality to export project data from MongoDB to a CSV file.
- The CSV export includes key fields such as id, reported, fiscal_year, borough, sponsor, title, description, budget_line, and award.
- The exported CSV is saved in the 'public/exports' directory.